### PR TITLE
Support for dynamic font, dark/light mode and configurable color and line count options for paragraph/list/code etc. elements.

### DIFF
--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -18,7 +18,8 @@ public struct Markdownosaur: MarkupVisitor {
   var codeColor = UIColor.systemGray
   var quoteColor = UIColor.systemGray
   var linkColor = UIColor.link // Warning: If you aim to use the markdown string in a UITextView, the link color is determined by its tintColor.
-  let listLines: UInt = 1
+  var listLeftMargin: CGFloat = 15.0
+  let listLines: UInt = 2
   let paragraphLines: UInt = 2
   let codeLines: UInt = 1
   
@@ -144,9 +145,9 @@ public struct Markdownosaur: MarkupVisitor {
       
       let listItemParagraphStyle = NSMutableParagraphStyle()
       
-      let baseLeftMargin: CGFloat = 15.0
+      let baseLeftMargin = listLeftMargin
       let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(unorderedList.listDepth))
-      let spacingFromIndex: CGFloat = 8.0
+      let spacingFromIndex: CGFloat = 5.0
       let bulletWidth = ceil(NSAttributedString(string: "•", attributes: [.font: font]).size().width)
       let firstTabLocation = leftMarginOffset + bulletWidth
       let secondTabLocation = firstTabLocation + spacingFromIndex
@@ -199,14 +200,14 @@ public struct Markdownosaur: MarkupVisitor {
       let listItemParagraphStyle = NSMutableParagraphStyle()
       
       // Implement a base amount to be spaced from the left side at all times to better visually differentiate it as a list
-      let baseLeftMargin: CGFloat = 15.0
+      let baseLeftMargin = listLeftMargin
       let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(orderedList.listDepth))
       
       // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
       let highestNumberInList = orderedList.childCount
       let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: monospacedDigitFont]).size().width)
       
-      let spacingFromIndex: CGFloat = 8.0
+      let spacingFromIndex: CGFloat = 5.0
       let firstTabLocation = leftMarginOffset + numeralColumnWidth
       let secondTabLocation = firstTabLocation + spacingFromIndex
       
@@ -430,14 +431,16 @@ extension NSAttributedString {
 
 extension String {
   /// Creates and returns a markdown formatted string.
-  func markdownString(alignment: NSTextAlignment = .natural, textColor: UIColor = .label, codeColor: UIColor = .systemGray, quoteColor: UIColor = .systemGray, linkColor: UIColor = .link) -> NSAttributedString {
-    let document = Document(parsing: self)
+  func markdownString(alignment: NSTextAlignment = .natural, textColor: UIColor = .label, codeColor: UIColor = .systemGray, quoteColor: UIColor = .systemGray, linkColor: UIColor = .link, listLeftMargin: CGFloat = 15.0) -> NSAttributedString {
+    let string = self.replacingOccurrences(of: #"\"#, with: #"\\"#)
+    let document = Document(parsing: string)
     
     var markdownosaur = Markdownosaur()
     markdownosaur.textColor = textColor
     markdownosaur.codeColor = codeColor
     markdownosaur.quoteColor = quoteColor
     markdownosaur.linkColor = linkColor
+    markdownosaur.listLeftMargin = listLeftMargin
     
     let attributedString = markdownosaur.attributedString(from: document)
     
@@ -452,5 +455,16 @@ extension String {
     }
     
     return attributedString
+  }
+  
+  var markdownRemoved: String
+  {
+    let replacements = [
+      ("*", "")
+    ]
+    
+    return replacements.reduce(self) { string, replacement in
+      string.replacingOccurrences(of: replacement.0, with: replacement.1)
+    }
   }
 }

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -12,6 +12,7 @@ public struct Markdownosaur: MarkupVisitor {
   let font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17.0))
   let monospacedFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedSystemFont(ofSize: 16.0, weight: .regular))
   let monospacedDigitFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedDigitSystemFont(ofSize: 17.0, weight: .regular))
+  let listNewLineFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 8.0))
   let color = UIColor.label
   let codeColor = UIColor.systemGray
   let quoteColor = UIColor.systemGray
@@ -182,7 +183,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if listItem.hasSuccessor {
-      result.append(.newline(withFont: font, count: listLines))
+      result.append(.newline(withFont: listNewLineFont, count: listLines))
     }
     
     return result
@@ -327,7 +328,10 @@ extension UIFont {
     existingTraits.insert(newTraits)
     
     guard let newFontDescriptor = fontDescriptor.withSymbolicTraits(existingTraits) else { return self }
-    return UIFont(descriptor: newFontDescriptor, size: newPointSize ?? pointSize)
+    
+    let newFont = UIFont(descriptor: newFontDescriptor, size: newPointSize ?? pointSize)
+    
+    return UIFontMetrics(forTextStyle: .body).scaledFont(for: newFont)
   }
 }
 

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -327,9 +327,14 @@ extension UIFont {
     var existingTraits = fontDescriptor.symbolicTraits
     existingTraits.insert(newTraits)
     
+    let font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17.0))
+    let scale = font.pointSize/17.0
+    
     guard let newFontDescriptor = fontDescriptor.withSymbolicTraits(existingTraits) else { return self }
     
-    let newFont = UIFont(descriptor: newFontDescriptor, size: newPointSize ?? pointSize)
+    let newSize = newPointSize != nil ? newPointSize!/scale : pointSize/scale
+    
+    let newFont = UIFont(descriptor: newFontDescriptor, size: newSize)
     
     return UIFontMetrics(forTextStyle: .body).scaledFont(for: newFont)
   }

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -9,16 +9,16 @@ import UIKit
 import Markdown
 
 public struct Markdownosaur: MarkupVisitor {
-  static let font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17.0))
-  static let monospacedFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedSystemFont(ofSize: 16.0, weight: .regular))
-  static let monospacedDigitFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedDigitSystemFont(ofSize: 17.0, weight: .regular))
-  static let color = UIColor.label
-  static let codeColor = UIColor.systemGray
-  static let quoteColor = UIColor.systemGray
-  static let linkColor = UIColor.systemBlue
-  static let listLines: UInt = 2
-  static let paragraphLines: UInt = 2
-  static let codeLines: UInt = 1
+  let font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17.0))
+  let monospacedFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedSystemFont(ofSize: 16.0, weight: .regular))
+  let monospacedDigitFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedDigitSystemFont(ofSize: 17.0, weight: .regular))
+  let color = UIColor.label
+  let codeColor = UIColor.systemGray
+  let quoteColor = UIColor.systemGray
+  let linkColor = UIColor.systemBlue
+  let listLines: UInt = 1
+  let paragraphLines: UInt = 2
+  let codeLines: UInt = 1
   
   public init() {}
   
@@ -37,7 +37,7 @@ public struct Markdownosaur: MarkupVisitor {
   }
   
   mutating public func visitText(_ text: Text) -> NSAttributedString {
-    return NSAttributedString(string: text.plainText, attributes: [.font: Markdownosaur.font, .foregroundColor: Markdownosaur.color])
+    return NSAttributedString(string: text.plainText, attributes: [.font: font, .foregroundColor: color])
   }
   
   mutating public func visitEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
@@ -72,7 +72,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if paragraph.hasSuccessor {
-      result.append(paragraph.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(paragraph.isContainedInList ? .newline(withFont: font, count: listLines) : .newline(withFont: font, count: paragraphLines))
     }
     
     return result
@@ -88,7 +88,7 @@ public struct Markdownosaur: MarkupVisitor {
     result.applyHeading(withLevel: heading.level)
     
     if heading.hasSuccessor {
-      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(.newline(withFont: font, count: paragraphLines))
     }
     
     return result
@@ -103,20 +103,20 @@ public struct Markdownosaur: MarkupVisitor {
     
     let url = link.destination != nil ? URL(string: link.destination!) : nil
     
-    result.applyLink(withURL: url)
+    result.applyLink(withURL: url, color: linkColor)
     
     return result
   }
   
   mutating public func visitInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
-    return NSAttributedString(string: inlineCode.code, attributes: [.font: Markdownosaur.monospacedFont, .foregroundColor: Markdownosaur.codeColor])
+    return NSAttributedString(string: inlineCode.code, attributes: [.font: monospacedFont, .foregroundColor: codeColor])
   }
   
   public func visitCodeBlock(_ codeBlock: CodeBlock) -> NSAttributedString {
-    let result = NSMutableAttributedString(string: codeBlock.code, attributes: [.font: Markdownosaur.monospacedFont, .foregroundColor: Markdownosaur.codeColor])
+    let result = NSMutableAttributedString(string: codeBlock.code, attributes: [.font: monospacedFont, .foregroundColor: codeColor])
     
     if codeBlock.hasSuccessor {
-      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.codeLines))
+      result.append(.newline(withFont: font, count: codeLines))
     }
     
     return result
@@ -145,7 +145,7 @@ public struct Markdownosaur: MarkupVisitor {
       let baseLeftMargin: CGFloat = 15.0
       let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(unorderedList.listDepth))
       let spacingFromIndex: CGFloat = 8.0
-      let bulletWidth = ceil(NSAttributedString(string: "•", attributes: [.font: Markdownosaur.font]).size().width)
+      let bulletWidth = ceil(NSAttributedString(string: "•", attributes: [.font: font]).size().width)
       let firstTabLocation = leftMarginOffset + bulletWidth
       let secondTabLocation = firstTabLocation + spacingFromIndex
       
@@ -157,8 +157,8 @@ public struct Markdownosaur: MarkupVisitor {
       listItemParagraphStyle.headIndent = secondTabLocation
       
       listItemAttributes[.paragraphStyle] = listItemParagraphStyle
-      listItemAttributes[.font] = Markdownosaur.font
-      listItemAttributes[.foregroundColor] = Markdownosaur.color
+      listItemAttributes[.font] = font
+      listItemAttributes[.foregroundColor] = color
       listItemAttributes[.listDepth] = unorderedList.listDepth
       
       let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
@@ -168,7 +168,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if unorderedList.hasSuccessor {
-      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(.newline(withFont: font, count: paragraphLines))
     }
     
     return result
@@ -182,7 +182,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if listItem.hasSuccessor {
-      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines))
+      result.append(.newline(withFont: font, count: listLines))
     }
     
     return result
@@ -202,7 +202,7 @@ public struct Markdownosaur: MarkupVisitor {
       
       // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
       let highestNumberInList = orderedList.childCount
-      let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: Markdownosaur.monospacedDigitFont]).size().width)
+      let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: monospacedDigitFont]).size().width)
       
       let spacingFromIndex: CGFloat = 8.0
       let firstTabLocation = leftMarginOffset + numeralColumnWidth
@@ -216,15 +216,15 @@ public struct Markdownosaur: MarkupVisitor {
       listItemParagraphStyle.headIndent = secondTabLocation
       
       listItemAttributes[.paragraphStyle] = listItemParagraphStyle
-      listItemAttributes[.font] = Markdownosaur.font
-      listItemAttributes[.foregroundColor] = Markdownosaur.color
+      listItemAttributes[.font] = font
+      listItemAttributes[.foregroundColor] = color
       listItemAttributes[.listDepth] = orderedList.listDepth
       
       let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
       
       // Same as the normal list attributes, but for prettiness in formatting we want to use the cool monospaced numeral font
       var numberAttributes = listItemAttributes
-      numberAttributes[.font] = Markdownosaur.monospacedDigitFont
+      numberAttributes[.font] = monospacedDigitFont
       
       let numberAttributedString = NSAttributedString(string: "\t\(index + 1).\t", attributes: numberAttributes)
       listItemAttributedString.insert(numberAttributedString, at: 0)
@@ -233,7 +233,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if orderedList.hasSuccessor {
-      result.append(orderedList.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(orderedList.isContainedInList ? .newline(withFont: font, count: listLines) : .newline(withFont: font, count: paragraphLines))
     }
     
     return result
@@ -255,19 +255,19 @@ public struct Markdownosaur: MarkupVisitor {
       quoteParagraphStyle.headIndent = leftMarginOffset
       
       quoteAttributes[.paragraphStyle] = quoteParagraphStyle
-      quoteAttributes[.font] = Markdownosaur.font
+      quoteAttributes[.font] = font
       quoteAttributes[.listDepth] = blockQuote.quoteDepth
       
       let quoteAttributedString = visit(child).mutableCopy() as! NSMutableAttributedString
       quoteAttributedString.insert(NSAttributedString(string: "\t", attributes: quoteAttributes), at: 0)
       
-      quoteAttributedString.addAttribute(.foregroundColor, value: Markdownosaur.quoteColor)
+      quoteAttributedString.addAttribute(.foregroundColor, value: quoteColor)
       
       result.append(quoteAttributedString)
     }
     
     if blockQuote.hasSuccessor {
-      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(.newline(withFont: font, count: paragraphLines))
     }
     
     return result
@@ -295,16 +295,16 @@ extension NSMutableAttributedString {
     }
   }
   
-  func applyLink(withURL url: URL?) {
-    addAttribute(.foregroundColor, value: Markdownosaur.linkColor)
+  func applyLink(withURL url: URL?, color: UIColor) {
+    addAttribute(.foregroundColor, value: color)
     
     if let url = url {
       addAttribute(.link, value: url)
     }
   }
   
-  func applyBlockquote() {
-    addAttribute(.foregroundColor, value: Markdownosaur.quoteColor)
+  func applyBlockquote(color: UIColor) {
+    addAttribute(.foregroundColor, value: color)
   }
   
   func applyHeading(withLevel headingLevel: Int) {

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -9,403 +9,407 @@ import UIKit
 import Markdown
 
 public struct Markdownosaur: MarkupVisitor {
-    let baseFontSize: CGFloat = 15.0
-
-    public init() {}
+  static let font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17.0))
+  static let monospacedFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedSystemFont(ofSize: 16.0, weight: .regular))
+  static let monospacedDigitFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedDigitSystemFont(ofSize: 17.0, weight: .regular))
+  static let color = UIColor.label
+  static let codeColor = UIColor.systemGray
+  static let quoteColor = UIColor.systemGray
+  static let linkColor = UIColor.systemBlue
+  static let listLines: UInt = 2
+  static let paragraphLines: UInt = 2
+  static let codeLines: UInt = 1
+  
+  public init() {}
+  
+  public mutating func attributedString(from document: Document) -> NSAttributedString {
+    return visit(document)
+  }
+  
+  mutating public func defaultVisit(_ markup: Markup) -> NSAttributedString {
+    let result = NSMutableAttributedString()
     
-    public mutating func attributedString(from document: Document) -> NSAttributedString {
-        return visit(document)
+    for child in markup.children {
+      result.append(visit(child))
     }
     
-    mutating public func defaultVisit(_ markup: Markup) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in markup.children {
-            result.append(visit(child))
-        }
-        
-        return result
+    return result
+  }
+  
+  mutating public func visitText(_ text: Text) -> NSAttributedString {
+    return NSAttributedString(string: text.plainText, attributes: [.font: Markdownosaur.font, .foregroundColor: Markdownosaur.color])
+  }
+  
+  mutating public func visitEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in emphasis.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitText(_ text: Text) -> NSAttributedString {
-        return NSAttributedString(string: text.plainText, attributes: [.font: UIFont.systemFont(ofSize: baseFontSize, weight: .regular)])
+    result.applyEmphasis()
+    
+    return result
+  }
+  
+  mutating public func visitStrong(_ strong: Strong) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in strong.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in emphasis.children {
-            result.append(visit(child))
-        }
-        
-        result.applyEmphasis()
-        
-        return result
+    result.applyStrong()
+    
+    return result
+  }
+  
+  mutating public func visitParagraph(_ paragraph: Paragraph) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in paragraph.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitStrong(_ strong: Strong) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in strong.children {
-            result.append(visit(child))
-        }
-        
-        result.applyStrong()
-        
-        return result
+    if paragraph.hasSuccessor {
+      result.append(paragraph.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
     }
     
-    mutating public func visitParagraph(_ paragraph: Paragraph) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in paragraph.children {
-            result.append(visit(child))
-        }
-        
-        if paragraph.hasSuccessor {
-            result.append(paragraph.isContainedInList ? .singleNewline(withFontSize: baseFontSize) : .doubleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    return result
+  }
+  
+  mutating public func visitHeading(_ heading: Heading) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in heading.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitHeading(_ heading: Heading) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in heading.children {
-            result.append(visit(child))
-        }
-        
-        result.applyHeading(withLevel: heading.level)
-        
-        if heading.hasSuccessor {
-            result.append(.doubleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    result.applyHeading(withLevel: heading.level)
+    
+    if heading.hasSuccessor {
+      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
     }
     
-    mutating public func visitLink(_ link: Link) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in link.children {
-            result.append(visit(child))
-        }
-        
-        let url = link.destination != nil ? URL(string: link.destination!) : nil
-        
-        result.applyLink(withURL: url)
-        
-        return result
+    return result
+  }
+  
+  mutating public func visitLink(_ link: Link) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in link.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
-        return NSAttributedString(string: inlineCode.code, attributes: [.font: UIFont.monospacedSystemFont(ofSize: baseFontSize - 1.0, weight: .regular), .foregroundColor: UIColor.systemGray])
+    let url = link.destination != nil ? URL(string: link.destination!) : nil
+    
+    result.applyLink(withURL: url)
+    
+    return result
+  }
+  
+  mutating public func visitInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
+    return NSAttributedString(string: inlineCode.code, attributes: [.font: Markdownosaur.monospacedFont, .foregroundColor: Markdownosaur.codeColor])
+  }
+  
+  public func visitCodeBlock(_ codeBlock: CodeBlock) -> NSAttributedString {
+    let result = NSMutableAttributedString(string: codeBlock.code, attributes: [.font: Markdownosaur.monospacedFont, .foregroundColor: Markdownosaur.codeColor])
+    
+    if codeBlock.hasSuccessor {
+      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.codeLines))
     }
     
-    public func visitCodeBlock(_ codeBlock: CodeBlock) -> NSAttributedString {
-        let result = NSMutableAttributedString(string: codeBlock.code, attributes: [.font: UIFont.monospacedSystemFont(ofSize: baseFontSize - 1.0, weight: .regular), .foregroundColor: UIColor.systemGray])
-        
-        if codeBlock.hasSuccessor {
-            result.append(.singleNewline(withFontSize: baseFontSize))
-        }
+    return result
+  }
+  
+  mutating public func visitStrikethrough(_ strikethrough: Strikethrough) -> NSAttributedString {
+    let result = NSMutableAttributedString()
     
-        return result
+    for child in strikethrough.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitStrikethrough(_ strikethrough: Strikethrough) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in strikethrough.children {
-            result.append(visit(child))
-        }
-        
-        result.applyStrikethrough()
-        
-        return result
+    result.applyStrikethrough()
+    
+    return result
+  }
+  
+  mutating public func visitUnorderedList(_ unorderedList: UnorderedList) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for listItem in unorderedList.listItems {
+      var listItemAttributes: [NSAttributedString.Key: Any] = [:]
+      
+      let listItemParagraphStyle = NSMutableParagraphStyle()
+      
+      let baseLeftMargin: CGFloat = 15.0
+      let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(unorderedList.listDepth))
+      let spacingFromIndex: CGFloat = 8.0
+      let bulletWidth = ceil(NSAttributedString(string: "•", attributes: [.font: Markdownosaur.font]).size().width)
+      let firstTabLocation = leftMarginOffset + bulletWidth
+      let secondTabLocation = firstTabLocation + spacingFromIndex
+      
+      listItemParagraphStyle.tabStops = [
+        NSTextTab(textAlignment: .right, location: firstTabLocation),
+        NSTextTab(textAlignment: .left, location: secondTabLocation)
+      ]
+      
+      listItemParagraphStyle.headIndent = secondTabLocation
+      
+      listItemAttributes[.paragraphStyle] = listItemParagraphStyle
+      listItemAttributes[.font] = Markdownosaur.font
+      listItemAttributes[.foregroundColor] = Markdownosaur.color
+      listItemAttributes[.listDepth] = unorderedList.listDepth
+      
+      let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
+      listItemAttributedString.insert(NSAttributedString(string: "\t•\t", attributes: listItemAttributes), at: 0)
+      
+      result.append(listItemAttributedString)
     }
     
-    mutating public func visitUnorderedList(_ unorderedList: UnorderedList) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        let font = UIFont.systemFont(ofSize: baseFontSize, weight: .regular)
-                
-        for listItem in unorderedList.listItems {
-            var listItemAttributes: [NSAttributedString.Key: Any] = [:]
-            
-            let listItemParagraphStyle = NSMutableParagraphStyle()
-            
-            let baseLeftMargin: CGFloat = 15.0
-            let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(unorderedList.listDepth))
-            let spacingFromIndex: CGFloat = 8.0
-            let bulletWidth = ceil(NSAttributedString(string: "•", attributes: [.font: font]).size().width)
-            let firstTabLocation = leftMarginOffset + bulletWidth
-            let secondTabLocation = firstTabLocation + spacingFromIndex
-            
-            listItemParagraphStyle.tabStops = [
-                NSTextTab(textAlignment: .right, location: firstTabLocation),
-                NSTextTab(textAlignment: .left, location: secondTabLocation)
-            ]
-            
-            listItemParagraphStyle.headIndent = secondTabLocation
-            
-            listItemAttributes[.paragraphStyle] = listItemParagraphStyle
-            listItemAttributes[.font] = UIFont.systemFont(ofSize: baseFontSize, weight: .regular)
-            listItemAttributes[.listDepth] = unorderedList.listDepth
-            
-            let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
-            listItemAttributedString.insert(NSAttributedString(string: "\t•\t", attributes: listItemAttributes), at: 0)
-            
-            result.append(listItemAttributedString)
-        }
-        
-        if unorderedList.hasSuccessor {
-            result.append(.doubleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    if unorderedList.hasSuccessor {
+      result.append(unorderedList.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
     }
     
-    mutating public func visitListItem(_ listItem: ListItem) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in listItem.children {
-            result.append(visit(child))
-        }
-        
-        if listItem.hasSuccessor {
-            result.append(.singleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    return result
+  }
+  
+  mutating public func visitListItem(_ listItem: ListItem) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in listItem.children {
+      result.append(visit(child))
     }
     
-    mutating public func visitOrderedList(_ orderedList: OrderedList) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for (index, listItem) in orderedList.listItems.enumerated() {
-            var listItemAttributes: [NSAttributedString.Key: Any] = [:]
-            
-            let font = UIFont.systemFont(ofSize: baseFontSize, weight: .regular)
-            let numeralFont = UIFont.monospacedDigitSystemFont(ofSize: baseFontSize, weight: .regular)
-            
-            let listItemParagraphStyle = NSMutableParagraphStyle()
-            
-            // Implement a base amount to be spaced from the left side at all times to better visually differentiate it as a list
-            let baseLeftMargin: CGFloat = 15.0
-            let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(orderedList.listDepth))
-            
-            // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
-            let highestNumberInList = orderedList.childCount
-            let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: numeralFont]).size().width)
-            
-            let spacingFromIndex: CGFloat = 8.0
-            let firstTabLocation = leftMarginOffset + numeralColumnWidth
-            let secondTabLocation = firstTabLocation + spacingFromIndex
-            
-            listItemParagraphStyle.tabStops = [
-                NSTextTab(textAlignment: .right, location: firstTabLocation),
-                NSTextTab(textAlignment: .left, location: secondTabLocation)
-            ]
-            
-            listItemParagraphStyle.headIndent = secondTabLocation
-            
-            listItemAttributes[.paragraphStyle] = listItemParagraphStyle
-            listItemAttributes[.font] = font
-            listItemAttributes[.listDepth] = orderedList.listDepth
-
-            let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
-            
-            // Same as the normal list attributes, but for prettiness in formatting we want to use the cool monospaced numeral font
-            var numberAttributes = listItemAttributes
-            numberAttributes[.font] = numeralFont
-            
-            let numberAttributedString = NSAttributedString(string: "\t\(index + 1).\t", attributes: numberAttributes)
-            listItemAttributedString.insert(numberAttributedString, at: 0)
-            
-            result.append(listItemAttributedString)
-        }
-        
-        if orderedList.hasSuccessor {
-            result.append(orderedList.isContainedInList ? .singleNewline(withFontSize: baseFontSize) : .doubleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    if listItem.hasSuccessor {
+      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines))
     }
     
-    mutating public func visitBlockQuote(_ blockQuote: BlockQuote) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        
-        for child in blockQuote.children {
-            var quoteAttributes: [NSAttributedString.Key: Any] = [:]
-            
-            let quoteParagraphStyle = NSMutableParagraphStyle()
-            
-            let baseLeftMargin: CGFloat = 15.0
-            let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(blockQuote.quoteDepth))
-            
-            quoteParagraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: leftMarginOffset)]
-            
-            quoteParagraphStyle.headIndent = leftMarginOffset
-            
-            quoteAttributes[.paragraphStyle] = quoteParagraphStyle
-            quoteAttributes[.font] = UIFont.systemFont(ofSize: baseFontSize, weight: .regular)
-            quoteAttributes[.listDepth] = blockQuote.quoteDepth
-            
-            let quoteAttributedString = visit(child).mutableCopy() as! NSMutableAttributedString
-            quoteAttributedString.insert(NSAttributedString(string: "\t", attributes: quoteAttributes), at: 0)
-            
-            quoteAttributedString.addAttribute(.foregroundColor, value: UIColor.systemGray)
-            
-            result.append(quoteAttributedString)
-        }
-        
-        if blockQuote.hasSuccessor {
-            result.append(.doubleNewline(withFontSize: baseFontSize))
-        }
-        
-        return result
+    return result
+  }
+  
+  mutating public func visitOrderedList(_ orderedList: OrderedList) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for (index, listItem) in orderedList.listItems.enumerated() {
+      var listItemAttributes: [NSAttributedString.Key: Any] = [:]
+      
+      let listItemParagraphStyle = NSMutableParagraphStyle()
+      
+      // Implement a base amount to be spaced from the left side at all times to better visually differentiate it as a list
+      let baseLeftMargin: CGFloat = 15.0
+      let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(orderedList.listDepth))
+      
+      // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
+      let highestNumberInList = orderedList.childCount
+      let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: Markdownosaur.monospacedDigitFont]).size().width)
+      
+      let spacingFromIndex: CGFloat = 8.0
+      let firstTabLocation = leftMarginOffset + numeralColumnWidth
+      let secondTabLocation = firstTabLocation + spacingFromIndex
+      
+      listItemParagraphStyle.tabStops = [
+        NSTextTab(textAlignment: .right, location: firstTabLocation),
+        NSTextTab(textAlignment: .left, location: secondTabLocation)
+      ]
+      
+      listItemParagraphStyle.headIndent = secondTabLocation
+      
+      listItemAttributes[.paragraphStyle] = listItemParagraphStyle
+      listItemAttributes[.font] = Markdownosaur.font
+      listItemAttributes[.foregroundColor] = Markdownosaur.color
+      listItemAttributes[.listDepth] = orderedList.listDepth
+      
+      let listItemAttributedString = visit(listItem).mutableCopy() as! NSMutableAttributedString
+      
+      // Same as the normal list attributes, but for prettiness in formatting we want to use the cool monospaced numeral font
+      var numberAttributes = listItemAttributes
+      numberAttributes[.font] = Markdownosaur.monospacedDigitFont
+      
+      let numberAttributedString = NSAttributedString(string: "\t\(index + 1).\t", attributes: numberAttributes)
+      listItemAttributedString.insert(numberAttributedString, at: 0)
+      
+      result.append(listItemAttributedString)
     }
+    
+    if orderedList.hasSuccessor {
+      result.append(orderedList.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+    }
+    
+    return result
+  }
+  
+  mutating public func visitBlockQuote(_ blockQuote: BlockQuote) -> NSAttributedString {
+    let result = NSMutableAttributedString()
+    
+    for child in blockQuote.children {
+      var quoteAttributes: [NSAttributedString.Key: Any] = [:]
+      
+      let quoteParagraphStyle = NSMutableParagraphStyle()
+      
+      let baseLeftMargin: CGFloat = 15.0
+      let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(blockQuote.quoteDepth))
+      
+      quoteParagraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: leftMarginOffset)]
+      
+      quoteParagraphStyle.headIndent = leftMarginOffset
+      
+      quoteAttributes[.paragraphStyle] = quoteParagraphStyle
+      quoteAttributes[.font] = Markdownosaur.font
+      quoteAttributes[.listDepth] = blockQuote.quoteDepth
+      
+      let quoteAttributedString = visit(child).mutableCopy() as! NSMutableAttributedString
+      quoteAttributedString.insert(NSAttributedString(string: "\t", attributes: quoteAttributes), at: 0)
+      
+      quoteAttributedString.addAttribute(.foregroundColor, value: Markdownosaur.quoteColor)
+      
+      result.append(quoteAttributedString)
+    }
+    
+    if blockQuote.hasSuccessor {
+      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+    }
+    
+    return result
+  }
 }
 
 // MARK: - Extensions Land
 
 extension NSMutableAttributedString {
-    func applyEmphasis() {
-        enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
-            guard let font = value as? UIFont else { return }
-            
-            let newFont = font.apply(newTraits: .traitItalic)
-            addAttribute(.font, value: newFont, range: range)
-        }
+  func applyEmphasis() {
+    enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
+      guard let font = value as? UIFont else { return }
+      
+      let newFont = font.apply(newTraits: .traitItalic)
+      addAttribute(.font, value: newFont, range: range)
     }
+  }
+  
+  func applyStrong() {
+    enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
+      guard let font = value as? UIFont else { return }
+      
+      let newFont = font.apply(newTraits: .traitBold)
+      addAttribute(.font, value: newFont, range: range)
+    }
+  }
+  
+  func applyLink(withURL url: URL?) {
+    addAttribute(.foregroundColor, value: Markdownosaur.linkColor)
     
-    func applyStrong() {
-        enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
-            guard let font = value as? UIFont else { return }
-            
-            let newFont = font.apply(newTraits: .traitBold)
-            addAttribute(.font, value: newFont, range: range)
-        }
+    if let url = url {
+      addAttribute(.link, value: url)
     }
-    
-    func applyLink(withURL url: URL?) {
-        addAttribute(.foregroundColor, value: UIColor.systemBlue)
-        
-        if let url = url {
-            addAttribute(.link, value: url)
-        }
+  }
+  
+  func applyBlockquote() {
+    addAttribute(.foregroundColor, value: Markdownosaur.quoteColor)
+  }
+  
+  func applyHeading(withLevel headingLevel: Int) {
+    enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
+      guard let font = value as? UIFont else { return }
+      
+      let newFont = font.apply(newTraits: .traitBold, newPointSize: 28.0 - CGFloat(headingLevel * 2))
+      addAttribute(.font, value: newFont, range: range)
     }
-    
-    func applyBlockquote() {
-        addAttribute(.foregroundColor, value: UIColor.systemGray)
-    }
-    
-    func applyHeading(withLevel headingLevel: Int) {
-        enumerateAttribute(.font, in: NSRange(location: 0, length: length), options: []) { value, range, stop in
-            guard let font = value as? UIFont else { return }
-            
-            let newFont = font.apply(newTraits: .traitBold, newPointSize: 28.0 - CGFloat(headingLevel * 2))
-            addAttribute(.font, value: newFont, range: range)
-        }
-    }
-    
-    func applyStrikethrough() {
-        addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue)
-    }
+  }
+  
+  func applyStrikethrough() {
+    addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue)
+  }
 }
 
 extension UIFont {
-    func apply(newTraits: UIFontDescriptor.SymbolicTraits, newPointSize: CGFloat? = nil) -> UIFont {
-        var existingTraits = fontDescriptor.symbolicTraits
-        existingTraits.insert(newTraits)
-        
-        guard let newFontDescriptor = fontDescriptor.withSymbolicTraits(existingTraits) else { return self }
-        return UIFont(descriptor: newFontDescriptor, size: newPointSize ?? pointSize)
-    }
+  func apply(newTraits: UIFontDescriptor.SymbolicTraits, newPointSize: CGFloat? = nil) -> UIFont {
+    var existingTraits = fontDescriptor.symbolicTraits
+    existingTraits.insert(newTraits)
+    
+    guard let newFontDescriptor = fontDescriptor.withSymbolicTraits(existingTraits) else { return self }
+    return UIFont(descriptor: newFontDescriptor, size: newPointSize ?? pointSize)
+  }
 }
 
 extension ListItemContainer {
-    /// Depth of the list if nested within others. Index starts at 0.
-    var listDepth: Int {
-        var index = 0
-
-        var currentElement = parent
-
-        while currentElement != nil {
-            if currentElement is ListItemContainer {
-                index += 1
-            }
-
-            currentElement = currentElement?.parent
-        }
-        
-        return index
+  /// Depth of the list if nested within others. Index starts at 0.
+  var listDepth: Int {
+    var index = 0
+    
+    var currentElement = parent
+    
+    while currentElement != nil {
+      if currentElement is ListItemContainer {
+        index += 1
+      }
+      
+      currentElement = currentElement?.parent
     }
+    
+    return index
+  }
 }
 
 extension BlockQuote {
-    /// Depth of the quote if nested within others. Index starts at 0.
-    var quoteDepth: Int {
-        var index = 0
-
-        var currentElement = parent
-
-        while currentElement != nil {
-            if currentElement is BlockQuote {
-                index += 1
-            }
-
-            currentElement = currentElement?.parent
-        }
-        
-        return index
+  /// Depth of the quote if nested within others. Index starts at 0.
+  var quoteDepth: Int {
+    var index = 0
+    
+    var currentElement = parent
+    
+    while currentElement != nil {
+      if currentElement is BlockQuote {
+        index += 1
+      }
+      
+      currentElement = currentElement?.parent
     }
+    
+    return index
+  }
 }
 
 extension NSAttributedString.Key {
-    static let listDepth = NSAttributedString.Key("ListDepth")
-    static let quoteDepth = NSAttributedString.Key("QuoteDepth")
+  static let listDepth = NSAttributedString.Key("ListDepth")
+  static let quoteDepth = NSAttributedString.Key("QuoteDepth")
 }
 
 extension NSMutableAttributedString {
-    func addAttribute(_ name: NSAttributedString.Key, value: Any) {
-        addAttribute(name, value: value, range: NSRange(location: 0, length: length))
-    }
-    
-    func addAttributes(_ attrs: [NSAttributedString.Key : Any]) {
-        addAttributes(attrs, range: NSRange(location: 0, length: length))
-    }
+  func addAttribute(_ name: NSAttributedString.Key, value: Any) {
+    addAttribute(name, value: value, range: NSRange(location: 0, length: length))
+  }
+  
+  func addAttributes(_ attrs: [NSAttributedString.Key : Any]) {
+    addAttributes(attrs, range: NSRange(location: 0, length: length))
+  }
 }
 
 extension Markup {
-    /// Returns true if this element has sibling elements after it.
-    var hasSuccessor: Bool {
-        guard let childCount = parent?.childCount else { return false }
-        return indexInParent < childCount - 1
+  /// Returns true if this element has sibling elements after it.
+  var hasSuccessor: Bool {
+    guard let childCount = parent?.childCount else { return false }
+    return indexInParent < childCount - 1
+  }
+  
+  var isContainedInList: Bool {
+    var currentElement = parent
+    
+    while currentElement != nil {
+      if currentElement is ListItemContainer {
+        return true
+      }
+      
+      currentElement = currentElement?.parent
     }
     
-    var isContainedInList: Bool {
-        var currentElement = parent
-
-        while currentElement != nil {
-            if currentElement is ListItemContainer {
-                return true
-            }
-
-            currentElement = currentElement?.parent
-        }
-        
-        return false
-    }
+    return false
+  }
 }
 
 extension NSAttributedString {
-    static func singleNewline(withFontSize fontSize: CGFloat) -> NSAttributedString {
-        return NSAttributedString(string: "\n", attributes: [.font: UIFont.systemFont(ofSize: fontSize, weight: .regular)])
-    }
-    
-    static func doubleNewline(withFontSize fontSize: CGFloat) -> NSAttributedString {
-        return NSAttributedString(string: "\n\n", attributes: [.font: UIFont.systemFont(ofSize: fontSize, weight: .regular)])
-    }
+  static func newline(withFont font: UIFont, count: UInt) -> NSAttributedString {
+    var line = ""
+    for _ in 0..<count { line.append("\n") }
+    return NSAttributedString(string: line, attributes: [.font: font])
+  }
 }

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -168,7 +168,7 @@ public struct Markdownosaur: MarkupVisitor {
     }
     
     if unorderedList.hasSuccessor {
-      result.append(unorderedList.isContainedInList ? .newline(withFont: Markdownosaur.font, count: Markdownosaur.listLines) : .newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
+      result.append(.newline(withFont: Markdownosaur.font, count: Markdownosaur.paragraphLines))
     }
     
     return result
@@ -413,3 +413,4 @@ extension NSAttributedString {
     return NSAttributedString(string: line, attributes: [.font: font])
   }
 }
+


### PR DESCRIPTION
Hi Christian,

I saw Markdownosaur on your subreddit and tried it. It works like a charm. But unfortunately it does not have support for dynamic fonts, dark mode font colors and configuring it is a slight challenge. For example, I like to have double newlines in my unordered lists, while Markdownosaur has no configuration options for it. Editing it is very easy but I thought being able to have some easy variables would not hurt.

So I updated the code a little :) As it has a lot of changes, I understand that you may not want to merge it, but I wanted to create a pull request so that others encountering such problems could perhaps take a look at it.

Thank you very much for such a great utility.

Cheers!